### PR TITLE
Add history replace to setQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ function RenderView(props) {
 }
 ```
 
+You can also add a replace option if you want `setQuery` to replace the last location in the history.
+
+```js
+import QueryParams from "react-qparams";
+
+function RenderView(props) {
+  return (
+    <QueryParams>
+      {query => (
+        <button onClick={() => query.setQuery({ tab: "other" }, { replace: true })}>
+          {query.tab || "default"}
+        </button>
+      )}
+    </QueryParams>
+  );
+}
+```
+
 ## Props
 
 ### `children` or `render`

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,21 @@ const QueryParams = withRouter(
       children: PropTypes.func,
       render: PropTypes.func
     };
-    setQuery = query => {
+    setQuery = (query, options = { replace: false }) => {
       let currentQuery = queryString.parse(this.props.location.search);
-      this.props.history.push({
-        search: queryString.stringify({
-          ...currentQuery,
-          ...query
-        })
-      });
+      options.replace
+        ? this.props.history.replace({
+            search: queryString.stringify({
+              ...currentQuery,
+              ...query
+            })
+          })
+        : this.props.history.push({
+            search: queryString.stringify({
+              ...currentQuery,
+              ...query
+            })
+          });
     };
     render() {
       const { location } = this.props;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import QueryParams from "./index";
-import { MemoryRouter, Route, Link } from "react-router-dom";
+import { MemoryRouter, Router, Route, Link } from "react-router-dom";
 import { mount } from "enzyme";
 
 describe("<QueryParams />", () => {
@@ -94,6 +94,35 @@ describe("<QueryParams />", () => {
       );
     });
     wrapper.find("button").simulate("click");
+    expect(wrapper.find("#url")).toHaveText("?b=c");
+    expect(wrapper.find("#a")).toHaveText("");
+    wrapper.unmount();
+  });
+  test("the query replaces the last location when replace is true", () => {
+    let wrapper = setup("?a=b&b=c", query => {
+      return (
+        <button
+          onClick={() =>
+            query.setQuery(
+              {
+                a: undefined
+              },
+              {
+                replace: true
+              }
+            )
+          }
+        >
+          <span id={"a"}>{query.a}</span>
+        </button>
+      );
+    });
+    let { history } = wrapper.find(Router).props();
+    expect(history.length).toBe(1);
+    expect(history.action).toBe("POP");
+    wrapper.find("button").simulate("click");
+    expect(history.length).toBe(1);
+    expect(history.action).toBe("REPLACE");
     expect(wrapper.find("#url")).toHaveText("?b=c");
     expect(wrapper.find("#a")).toHaveText("");
     wrapper.unmount();


### PR DESCRIPTION
Allows you to replace the last history location with setQuery by passing an options object to setQuery as its second argument, like so:	

`setQuery({ tab: "Default" }, { replace: true })`